### PR TITLE
background.scripts value must be an array of paths.

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ module.exports = function (options) {
 				contents: Buffer.concat(contents)
 			}));
 
-			manifest.set(prop, opts.background.target);
+			manifest.set(prop, [opts.background.target]);
   	} else if (backgrounds) {
   		backgrounds.forEach(function(src) {
   			this.push(new File({


### PR DESCRIPTION
Though opts.background.target is 'string' type, manifest.background.scripts value must be an array of paths. Otherwise, chrome fails to load the extension complaining about invalid value for 'background.scripts'.