### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (options) {
 		}
 
 		// patch version number
-		if (typeof opts.buildnumber === 'boolean') {
+		if (typeof opts.buildnumber === 'boolean' && opts.buildnumber) {
 			manifest.patch();
 		} else if (typeof opts.buildnumber === 'string') {
 			manifest.patch(opts.buildnumber);


### PR DESCRIPTION
Fix a bug where setting the 'buildnumber' option to false will still result in a version number increase.